### PR TITLE
adds blacklight.yml and ezid.yml to shared files

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@ set :keep_releases, 5
 
 set :assets_prefix, "#{shared_path}/public/assets"
 
-set :linked_files, %w{config/database.yml config/fedora.yml config/secrets.yml config/smtp.yml config/solr.yml config/environments/production.rb config/initializers/blacklight_initializer.rb config/initializers/devise.rb}
+set :linked_files, %w{config/blacklight.yml config/database.yml config/ezid.yml config/fedora.yml config/secrets.yml config/smtp.yml config/solr.yml config/environments/production.rb config/initializers/blacklight_initializer.rb config/initializers/devise.rb}
 
 set :linked_dirs, %w{tmp/pids tmp/cache tmp/sockets public/assets}
 


### PR DESCRIPTION
The sandbox server has the correct yaml files with the correct contents and format now. Once this PR is merged, "bundle exec cap aws deploy" will work to get the latest code onto the AWS server again. 