### PR TITLE
enable better searching for accession_number.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,7 +28,7 @@ class CatalogController < ApplicationController
     # config.show.partials.insert(1, :openseadragon)
 
     config.default_solr_params = {
-      qf: 'title_tesim lc_subject_label_tesim',
+      qf: 'title_tesim lc_subject_label_tesim accession_number_tesim',
       wt: 'json',
       qt: 'search',
       rows: 10
@@ -134,6 +134,13 @@ class CatalogController < ApplicationController
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
+
+    config.add_search_field('accession_number') do |field|
+      field.solr_local_parameters = {
+        :qf => 'accession_number_tesim',
+        :pf => 'accession_number_tesim'
+      }
+    end
 
     config.add_search_field('title') do |field|
       field.solr_local_parameters = {

--- a/app/models/concerns/metadata.rb
+++ b/app/models/concerns/metadata.rb
@@ -14,7 +14,7 @@ module Metadata
     end
 
     property :accession_number, predicate: ::RDF::URI('http://opaquenamespace.org/ns/cco/accessionNumber') do |index|
-      index.as :symbol # needed for exact match search in the CollectionFactory
+      index.as :symbol, :stored_searchable # symbol is needed for exact match search in the CollectionFactory
     end
 
     property :title, predicate: ::RDF::DC.title, multiple: false do |index|

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -241,6 +241,7 @@
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="_" replacement=" "/>
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.EnglishPossessiveFilterFactory"/>


### PR DESCRIPTION
* make accession_number searchable
* include accession_number_tesim in default solr search params
* update solr text_en tokenization to replace underscores with spaces to allow partial matches