### PR TITLE
add 'fedora:clean' rake task

### DIFF
--- a/lib/tasks/fedora.rake
+++ b/lib/tasks/fedora.rake
@@ -1,0 +1,19 @@
+namespace :fedora do
+  desc 'Cleans the ActiveFedora repository'
+  task clean: [:environment] do
+
+    if Rails.env.production? && ENV['DO_IT'].to_s.downcase != 'true'
+      puts "Failsafe: refusing to clean Fedora when RAILS_ENV=production"
+      puts
+      puts "If you really want to do this, run:"
+      puts "  DO_IT=true RAILS_ENV=production rake fedora:clean"
+    else
+      require 'active_fedora/cleaner'
+      puts "Cleaning Fedora via 'ActiveFedora.Cleaner.clean!' ..."
+      ActiveFedora::Cleaner.clean!
+      puts "Finished"
+    end
+
+  end
+end
+


### PR DESCRIPTION
Add a basic rake task for wiping out the fedora repo.

Includes a failsafe check for Rails.env.production

ping @jcoyne @val99erie