### PR TITLE
[test] commits from GH Enterprise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ rubocop:
 	rubocop --format simple --config .rubocop.yml --auto-correct
 
 spec:
-	RAILS_ENV=test bin/rake db:migrate
-	RAILS_ENV=test bundle exec rspec
+	CI=1 RAILS_ENV=test bundle exec rake ci --trace
 
 vagrant:
 	SERVER=127.0.0.1 REPO=/vagrant/alex2 bundle exec cap vagrant deploy

--- a/spec/fixtures/proquest/Flowers_ucsb_0035D_12540_DATA.xml
+++ b/spec/fixtures/proquest/Flowers_ucsb_0035D_12540_DATA.xml
@@ -9,6 +9,41 @@
         <DISS_suffix/>
         <DISS_affiliation>University of California, Santa Barbara</DISS_affiliation>
       </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship>N/A</DISS_citizenship>
     </DISS_author>
   </DISS_authorship>
   <DISS_description page_count="333" type="doctoral" external_id="http://dissertations.umi.com/ucsb:12540" apply_for_copyright="no">

--- a/spec/fixtures/proquest/French_ucsb_0035D_11752_DATA.xml
+++ b/spec/fixtures/proquest/French_ucsb_0035D_11752_DATA.xml
@@ -9,6 +9,41 @@
         <DISS_suffix/>
         <DISS_affiliation>University of California, Santa Barbara</DISS_affiliation>
       </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship>N/A</DISS_citizenship>
     </DISS_author>
   </DISS_authorship>
   <DISS_description page_count="402" type="doctoral" external_id="http://dissertations.umi.com/ucsb:11752" apply_for_copyright="yes">

--- a/spec/fixtures/proquest/Johnson_ucsb_0035N_12164_DATA.xml
+++ b/spec/fixtures/proquest/Johnson_ucsb_0035N_12164_DATA.xml
@@ -9,6 +9,41 @@
         <DISS_suffix/>
         <DISS_affiliation>University of California, Santa Barbara</DISS_affiliation>
       </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship>N/A</DISS_citizenship>
     </DISS_author>
   </DISS_authorship>
   <DISS_description page_count="20" type="masters" external_id="http://dissertations.umi.com/ucsb:12164" apply_for_copyright="no">

--- a/spec/fixtures/proquest/MartinezRodriguez_ucsb_0035D_12446_DATA.xml
+++ b/spec/fixtures/proquest/MartinezRodriguez_ucsb_0035D_12446_DATA.xml
@@ -9,6 +9,41 @@
         <DISS_suffix/>
         <DISS_affiliation>University of California, Santa Barbara</DISS_affiliation>
       </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship>N/A</DISS_citizenship>
     </DISS_author>
   </DISS_authorship>
   <DISS_description page_count="147" type="doctoral" external_id="http://dissertations.umi.com/ucsb:12446" apply_for_copyright="no">

--- a/spec/fixtures/proquest/Shockey_ucsb_0035D_11990_DATA.xml
+++ b/spec/fixtures/proquest/Shockey_ucsb_0035D_11990_DATA.xml
@@ -9,6 +9,41 @@
         <DISS_suffix/>
         <DISS_affiliation>University of California, Santa Barbara</DISS_affiliation>
       </DISS_name>
+      <DISS_contact type="current">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_contact type="future">
+        <DISS_contact_effdt>09/12/2014</DISS_contact_effdt>
+        <DISS_phone_fax type="P">
+          <DISS_cntry_cd>0</DISS_cntry_cd>
+          <DISS_area_code>666</DISS_area_code>
+          <DISS_phone_num>4201999</DISS_phone_num>
+          <DISS_phone_ext/>
+        </DISS_phone_fax>
+        <DISS_address>
+          <DISS_addrline>1 Fake Road</DISS_addrline>
+          <DISS_city>Unreal City</DISS_city>
+          <DISS_st>State of Denial</DISS_st>
+          <DISS_pcode>00000</DISS_pcode>
+          <DISS_country>Earth</DISS_country>
+        </DISS_address>
+        <DISS_email>fake@hotmail.con</DISS_email>
+      </DISS_contact>
+      <DISS_citizenship>N/A</DISS_citizenship>
     </DISS_author>
   </DISS_authorship>
   <DISS_description page_count="170" type="doctoral" external_id="http://dissertations.umi.com/ucsb:11990" apply_for_copyright="no">

--- a/spec/services/attach_files_to_etd_spec.rb
+++ b/spec/services/attach_files_to_etd_spec.rb
@@ -30,7 +30,7 @@ describe AttachFilesToETD do
       expect(etd.file_sets[1].original_file.mime_type).to eq 'image/tiff'
       expect(etd.file_sets[2].original_file.mime_type).to eq 'image/tiff'
 
-      expect(etd.proquest.size).to eq 4613
+      expect(etd.proquest.size).to eq 6005
     end
 
     it 'adds metadata from the ProQuest file to the ETD' do


### PR DESCRIPTION
Relatively minor changes:
- make `make spec` match how the CI works
- populate the ProQuest fixtures with fake contact data, to preserve all fields (just in case).