### PR TITLE
[deploy] remove ezid.yml from linked files

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,7 +38,6 @@ set :linked_files,
       config/application.yml
       config/blacklight.yml
       config/database.yml
-      config/ezid.yml
       config/fedora.yml
       config/ldap.yml
       config/redis.yml


### PR DESCRIPTION
Followup to https://github.com/curationexperts/alexandria-v2/pull/576