### PR TITLE
views/collections: fix image header display

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -6,7 +6,7 @@
 
 <div id="content" class="col-md-9 col-sm-8">
   <div itemscope itemtype="http://schema.org/CollectionPage" class="row">
-    <div class="col-sm-10 pull-right">
+    <div class="col-sm-10">
       <header>
         <h1><%= @presenter.title %></h1>
         <p class="collection_description"><%= @presenter.description %></p>


### PR DESCRIPTION
Should have been fixed in https://github.com/curationexperts/alexandria-v2/commit/9df2b1b7f913ac886f2268b3d93f07a64ec14ca5

<img width="1426" alt="pastedgraphic-1" src="https://cloud.githubusercontent.com/assets/985416/13118248/42305e92-d558-11e5-89b6-b70810407b82.png">
