### PR TITLE
cap deploys master branch by default

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,7 @@ set :linked_dirs, %w(
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
 # Default branch is :master
-ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
+set :branch, ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"
 
 # Default value for :pty is false
 # set :pty, true


### PR DESCRIPTION
Skips the prompt for what branch to deploy, deploys master by default. To deploy other branches, pass BRANCH_NAME. 