### PR TITLE
[css] fix padding/margins for search facet panel

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -441,7 +441,11 @@ table#downloads {
   background-color: inherit;
 }
 
-.panel-body {
+// JIRA: DIGREPO-472
+.panel-body ul {
+  margin-bottom: 0;
+}
+.show-tools .panel-body {
   padding: 5px 10px 20px 10px;
   li + li {
     margin-top: 1em;


### PR DESCRIPTION
Changes to the Tools panel in https://github.com/curationexperts/alexandria-v2/commit/0cd4714c7dd1d5be461eba3385a06812556c3ba9 caused issues for the faceting panel.

JIRA: DIGREPO-472