### PR TITLE
[deps] use https for github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'therubyracer', platforms: :ruby
 
-gem 'hydra-head', github: 'projecthydra/hydra-head', branch: 'replace_uri_with_graph'
+gem 'hydra-head', git: 'https://github.com/projecthydra/hydra-head.git', branch: 'replace_uri_with_graph'
 gem 'hydra-role-management'
-gem 'hydra-collections', github: 'projecthydra/hydra-collections'
-gem 'curation_concerns', github: 'projecthydra-labs/curation_concerns'
+gem 'hydra-collections', git: 'https://github.com/projecthydra/hydra-collections.git'
+gem 'curation_concerns', git: 'https://github.com/projecthydra-labs/curation_concerns.git'
 gem 'active-triples', '~> 0.7.5'
 gem 'rdf-marmotta', '~> 0.0.8'
 gem 'rdf-vocab', '~> 0.8.4'
@@ -29,19 +29,19 @@ gem 'settingslogic'
 gem 'rsolr', '~> 1.0.12'
 
 gem 'mods', '~> 2.0.3'
-gem 'oargun', github: 'curationexperts/oargun', ref: '8d4b556'
+gem 'oargun', git: 'https://github.com/curationexperts/oargun.git', ref: '8d4b556'
 gem 'linked_vocabs', '~> 0.3.1'
 gem 'riiif', '~> 0.2.0'
 gem 'ezid-client', '~> 1.2.0'
 gem 'qa', '~> 0.5.0'
 
-gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
+gem 'kaminari', git: 'https://github.com/jcoyne/kaminari.git', branch: 'sufia'
 
 gem 'devise', '~> 3.5.2'
 gem 'devise_ldap_authenticatable'
 gem 'devise-guests', '~> 0.5.0'
 
-gem 'traject', github: 'traject/traject', require: false, branch: 'allow_nil_default'
+gem 'traject', git: 'https://github.com/traject/traject.git', require: false, branch: 'allow_nil_default'
 
 gem 'resque-status'
 gem 'resque-pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/curationexperts/oargun.git
+  remote: https://github.com/curationexperts/oargun.git
   revision: 8d4b556107ca4c042380acb918cffd5b21baaeac
   ref: 8d4b556
   specs:
@@ -12,7 +12,7 @@ GIT
       rest-client (~> 1.7)
 
 GIT
-  remote: git://github.com/jcoyne/kaminari.git
+  remote: https://github.com/jcoyne/kaminari.git
   revision: 7f7108e12bdd64eb5a76177633768feb14df5453
   branch: sufia
   specs:
@@ -21,7 +21,7 @@ GIT
       activesupport (>= 3.0.0)
 
 GIT
-  remote: git://github.com/projecthydra-labs/curation_concerns.git
+  remote: https://github.com/projecthydra-labs/curation_concerns.git
   revision: cc5a5ed7e0fc4ef810032b52539c0089a29a23fd
   specs:
     curation_concerns (0.8.0)
@@ -47,7 +47,7 @@ GIT
       resque-pool (~> 0.3)
 
 GIT
-  remote: git://github.com/projecthydra/hydra-collections.git
+  remote: https://github.com/projecthydra/hydra-collections.git
   revision: 825f79fb6909b113886181adac95c49aab1198f6
   specs:
     hydra-collections (7.0.0)
@@ -59,7 +59,7 @@ GIT
       rdf-vocab (~> 0)
 
 GIT
-  remote: git://github.com/projecthydra/hydra-head.git
+  remote: https://github.com/projecthydra/hydra-head.git
   revision: aca8b16fb7b0c1625acb74afef19cdeb62764370
   branch: replace_uri_with_graph
   specs:
@@ -80,7 +80,7 @@ GIT
       rails (>= 3.2.6)
 
 GIT
-  remote: git://github.com/traject/traject.git
+  remote: https://github.com/traject/traject.git
   revision: 656a992c400a472bf5b738ec7a3aa208cc449472
   branch: allow_nil_default
   specs:
@@ -207,7 +207,7 @@ GEM
     bootstrap_form (2.3.0)
     breadcrumbs_on_rails (2.3.1)
     builder (3.2.2)
-    byebug (8.2.1)
+    byebug (8.2.2)
     cancancan (1.13.1)
     capistrano (3.4.0)
       i18n
@@ -218,10 +218,11 @@ GEM
       sshkit (~> 1.2)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
-    capistrano-rails (1.1.5)
+    capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (2.5.0)
+    capybara (2.6.2)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -245,7 +246,7 @@ GEM
     database_cleaner (1.5.1)
     deprecation (0.2.2)
       activesupport
-    devise (3.5.3)
+    devise (3.5.6)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -272,7 +273,7 @@ GEM
       hashie
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
+    factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     faraday (0.9.2)
@@ -282,7 +283,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.7)
       tilt
-    hashdiff (0.2.3)
+    hashdiff (0.3.0)
     hashie (3.4.3)
     htmlentities (4.3.4)
     http-cookie (1.0.2)
@@ -316,7 +317,7 @@ GEM
       hydra-pcdm (~> 0.4)
     i18n (0.7.0)
     iso-639 (0.2.5)
-    jbuilder (2.4.0)
+    jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
     jettywrapper (2.0.3)
@@ -412,12 +413,12 @@ GEM
     openseadragon (0.2.1)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
-    parser (2.3.0.5)
+    parser (2.3.0.6)
       ast (~> 2.2)
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
     pg (0.18.4)
-    poltergeist (1.8.1)
+    poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -546,11 +547,11 @@ GEM
       rails (> 3.2.0)
     rsolr (1.0.13)
       builder (>= 2.1.2)
-    rspec-activemodel-mocks (1.0.2)
+    rspec-activemodel-mocks (1.0.3)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       rspec-mocks (>= 2.99, < 4.0)
-    rspec-core (3.4.1)
+    rspec-core (3.4.3)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -558,7 +559,7 @@ GEM
     rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
-    rspec-rails (3.4.0)
+    rspec-rails (3.4.2)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
@@ -574,7 +575,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
     ruby-progressbar (1.7.5)
-    rubyzip (1.1.7)
+    rubyzip (1.2.0)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -610,7 +611,7 @@ GEM
     sparql-client (1.1.6)
       net-http-persistent (~> 2.9)
       rdf (~> 1.1)
-    spring (1.6.2)
+    spring (1.6.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (3.5.2)
@@ -655,9 +656,9 @@ GEM
     vcr (3.0.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
-    warden (1.2.4)
+    warden (1.2.6)
       rack (>= 1.0)
-    webmock (1.22.6)
+    webmock (1.24.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff


### PR DESCRIPTION
`git://` is insecure, and can fail on older versions of Git.