### PR TITLE
[provisioning] leave deploy_keys empty on prod run

### DIFF
--- a/ansible/adrl.yml
+++ b/ansible/adrl.yml
@@ -6,7 +6,7 @@
     deploy_user: adrl
     deploy_group: adrl
     deploy_keys:
-      - "https://github.com/{{ lookup('env', 'GH_USER') }}.keys"
+      - "{{ lookup('env', 'GH_USER') }}"
 
     server_name: "{{ lookup('env', 'SERVER') }}"
     project_base: /opt

--- a/bin/provision
+++ b/bin/provision
@@ -156,8 +156,9 @@ else
     echo -n "Enter your GitHub username (for fetching your public key): "
     read -r GH_USER
     echo "Setting GH_USER to '$GH_USER'"
-    export GH_USER
+    export GH_USER="https://github.com/$GH_USER.keys"
   fi
+
   echo "Setting EMAIL to '$EMAIL'"
   export EMAIL
 


### PR DESCRIPTION
We'll already have keys configured on production, so the easiest way to
skip this step is to have empty items in deploy_keys.