### PR TITLE
Fixed a problem where MODS parser was setting id but shouldn't be.  It was causing re-run of mods importer to create a new record instead of updating existing record.

### DIFF
--- a/lib/importer/mods_parser.rb
+++ b/lib/importer/mods_parser.rb
@@ -109,11 +109,7 @@ module Importer
     end
 
     def identifiers
-      human_readable_id = mods.identifier.map(&:text)
-      {
-        id: persistent_id(human_readable_id.first),
-        accession_number: human_readable_id,
-      }
+      { accession_number: mods.identifier.map(&:text) }
     end
 
     def record_origin
@@ -166,7 +162,7 @@ module Importer
     end
 
     def collection
-      { id: persistent_id(human_readable_id.first),
+      {
         accession_number: human_readable_id,
         title: collection_name,
       }

--- a/spec/importer/mods_parser_spec.rb
+++ b/spec/importer/mods_parser_spec.rb
@@ -110,7 +110,6 @@ describe Importer::ModsParser do
     end
 
     it 'finds metadata for the collection' do
-      expect(attributes[:collection][:id]).to eq 'sbhcmss78'
       expect(attributes[:collection][:accession_number]).to eq ['SBHC Mss 78']
       expect(attributes[:collection][:title]).to eq ['Joel Conway / Flying A Studio photograph collection']
     end
@@ -192,7 +191,6 @@ describe Importer::ModsParser do
     let(:file) { 'spec/fixtures/mods/sbhcmss78_FlyingAStudios_collection.xml' }
 
     it 'finds the metadata' do
-      expect(attributes[:id]).to eq 'sbhcmss78'
       expect(attributes[:accession_number]).to eq ['SBHC Mss 78']
       expect(attributes[:title]).to eq ['Joel Conway / Flying A Studio photograph collection']
       expect(attributes[:creator]).to be_nil


### PR DESCRIPTION
ping @jcoyne for review

I ran the mods importer script with 2 image files and 1 collection file from the sandbox:
/data/adrl-dm/ingest-ready/hpamss032

To test these changes:
* I tried running the collection import first, then the images import
* I tried running in the reverse order (images first, then import collection)
* I tried running the import script twice in a row to make sure the find_or_create behavior was working correctly

All these tests were run in my local dev env

After the imports, I checked the collection.member_ids and image.in_collection_ids to make sure the images were in the collection as expected.  It seems to be working properly and the specs all pass.