### PR TITLE
[ingest] fix "same file" copy error and clear proquest_dir

### DIFF
--- a/bin/ingest-etd
+++ b/bin/ingest-etd
@@ -11,7 +11,7 @@ Dir.mkdir Settings.download_root unless Pathname.new(Settings.download_root).exi
 Dir.mkdir Settings.marc_directory unless Pathname.new(Settings.marc_directory).exist?
 Dir.mkdir Settings.proquest_directory unless Pathname.new(Settings.proquest_directory).exist?
 
-output_file = "MARC_#{Time.now.to_i}.xml"
+output_file = File.join(Settings.marc_directory, "MARC_#{Time.now.to_i}.xml")
 Importer::ETDImporter.write_marc_file(ARGV, output_file)
 
 puts 'Now ingesting...'
@@ -20,7 +20,7 @@ require 'traject'
 require 'traject/command_line'
 args = ['-c', 'lib/traject/etd_config.rb']
 args << '-s' << "files_directory=#{Settings.proquest_directory}"
-args << File.join(Settings.marc_directory, output_file)
+args << output_file
 cmdline = Traject::CommandLine.new(args)
 result = cmdline.execute
 

--- a/bin/ingest-etd
+++ b/bin/ingest-etd
@@ -14,14 +14,25 @@ Dir.mkdir Settings.proquest_directory unless Pathname.new(Settings.proquest_dire
 output_file = File.join(Settings.marc_directory, "MARC_#{Time.now.to_i}.xml")
 Importer::ETDImporter.write_marc_file(ARGV, output_file)
 
-puts 'Now ingesting...'
+result = nil
+begin
+  ARGV.each do |zip|
+    unless File.dirname(zip) == Settings.proquest_directory
+      FileUtils.cp zip, Settings.proquest_directory
+    end
+  end
 
-require 'traject'
-require 'traject/command_line'
-args = ['-c', 'lib/traject/etd_config.rb']
-args << '-s' << "files_directory=#{Settings.proquest_directory}"
-args << output_file
-cmdline = Traject::CommandLine.new(args)
-result = cmdline.execute
+  puts 'Now ingesting...'
+
+  require 'traject'
+  require 'traject/command_line'
+  args = ['-c', 'lib/traject/etd_config.rb']
+  args << '-s' << "files_directory=#{Settings.proquest_directory}"
+  args << output_file
+  cmdline = Traject::CommandLine.new(args)
+  result = cmdline.execute
+ensure
+  FileUtils.rm_f Dir["#{Settings.proquest_directory}/*.zip"]
+end
 
 exit 1 unless result # non-zero exit status on process telling us there's problems.

--- a/lib/importer/etd_importer.rb
+++ b/lib/importer/etd_importer.rb
@@ -4,7 +4,7 @@ module Importer
     def self.write_marc_file(zipfiles, output_file)
       marcs = find_marc_for_zipfiles(zipfiles)
 
-      File.open(File.join(Settings.marc_directory, output_file), 'w') do |f|
+      File.open(output_file, 'w') do |f|
         f.write <<-EOS
 <?xml version="1.0"?>
 <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>#{marcs.count}</zs:numberOfRecords><zs:records>
@@ -12,7 +12,7 @@ module Importer
         f.write marcs.join("\n")
         f.write('</zs:records></zs:searchRetrieveResponse>')
 
-        puts "Wrote MARC metadata to #{Settings.marc_directory}/"
+        puts "Wrote MARC metadata to #{output_file}"
       end
     end
 

--- a/lib/importer/etd_importer.rb
+++ b/lib/importer/etd_importer.rb
@@ -3,7 +3,6 @@ module Importer
   module ETDImporter
     def self.write_marc_file(zipfiles, output_file)
       marcs = find_marc_for_zipfiles(zipfiles)
-      puts "Copied zipfiles to #{Settings.proquest_directory}"
 
       File.open(File.join(Settings.marc_directory, output_file), 'w') do |f|
         f.write <<-EOS
@@ -23,7 +22,10 @@ module Importer
       #
       # @return [Array]
       def self.unzip(zipfile, dest)
-        FileUtils.cp zipfile, Settings.proquest_directory
+        unless File.exist?("#{Settings.proquest_directory}/#{File.basename(zipfile)}")
+          FileUtils.cp zipfile, Settings.proquest_directory
+          puts "Copied zipfiles to #{Settings.proquest_directory}"
+        end
 
         xml ||= []
         system 'unzip', '-o', zipfile, '-d', dest

--- a/lib/importer/etd_importer.rb
+++ b/lib/importer/etd_importer.rb
@@ -22,11 +22,6 @@ module Importer
       #
       # @return [Array]
       def self.unzip(zipfile, dest)
-        unless File.exist?("#{Settings.proquest_directory}/#{File.basename(zipfile)}")
-          FileUtils.cp zipfile, Settings.proquest_directory
-          puts "Copied zipfiles to #{Settings.proquest_directory}"
-        end
-
         xml ||= []
         system 'unzip', '-o', zipfile, '-d', dest
 


### PR DESCRIPTION
Running e.g. `bin/ingest-etd /opt/download_root/proquest/etdadmin_upload_1*` would throw an error since the script tries to copy the zipfiles to the location they already exist at:
```
/usr/local/lib/ruby/2.3.0/fileutils.rb:1570:in `block in fu_each_src_dest': same file: /opt/download_root/proquest/etdadmin_upload_169666.zip and /opt/download_root/proquest/etdadmin_upload_169666.zip (ArgumentError)
        from /usr/local/lib/ruby/2.3.0/fileutils.rb:1585:in `fu_each_src_dest0'
        from /usr/local/lib/ruby/2.3.0/fileutils.rb:1569:in `fu_each_src_dest'
        from /usr/local/lib/ruby/2.3.0/fileutils.rb:402:in `cp'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:26:in `unzip'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:72:in `block (2 levels) in find_marc_for_zipfiles'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:72:in `map'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:72:in `block in find_marc_for_zipfiles'
        from /usr/local/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:70:in `find_marc_for_zipfiles'
        from /opt/alexandria-v2/releases/20160303233018/lib/importer/etd_importer.rb:5:in `write_marc_file'
        from bin/ingest-etd:15:in `<main>'
```
If that's not a common situation, though, maybe we should empty `proquest_directory` after each ingest, to avoid leaving ProQuest data in more locations than necessary.